### PR TITLE
Fix JWT auth token refreshing

### DIFF
--- a/transendence_dev_env/be/accounts/views.py
+++ b/transendence_dev_env/be/accounts/views.py
@@ -324,8 +324,10 @@ class VerifyOTPView(APIView):
 
 class TokenRefreshView(SimpleJWTTokenRefreshView):
     def post(self, request, *args, **kwargs):
+        logger.debug("got JWT refresh request")
         refresh_token = request.COOKIES.get('refresh_token')
         if not refresh_token:
+            logger.debug("no refresh token found in TokenRefreshView")
             return Response({"message": "Refresh token not found"}, status=status.HTTP_401_UNAUTHORIZED)
         
         serializer = self.get_serializer(data={'refresh': refresh_token})
@@ -339,6 +341,7 @@ class TokenRefreshView(SimpleJWTTokenRefreshView):
         
         # Update refresh token cookie if rotated
         if api_settings.ROTATE_REFRESH_TOKENS and new_refresh_token:
+            logger.debug("rotating JWT refresh token")
             response.set_cookie(
                 'refresh_token',
                 new_refresh_token,
@@ -347,6 +350,7 @@ class TokenRefreshView(SimpleJWTTokenRefreshView):
                 secure=False,
                 samesite='Lax' if besettings.DEBUG else 'None'
             )
+        logger.debug(f"Sending new access token: {response_data}")
         return response
 
 class UserViewSet(viewsets.ModelViewSet):

--- a/transendence_dev_env/be/be/settings.py
+++ b/transendence_dev_env/be/be/settings.py
@@ -113,7 +113,7 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # Keep your original access token lifetime
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=1000),  # Keep your original access token lifetime
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),  # Keep your original refresh token lifetime
     'ROTATE_REFRESH_TOKENS': True,  # Rotate refresh tokens upon use
     'BLACKLIST_AFTER_ROTATION': True,  # Blacklist old refresh tokens after they are used

--- a/transendence_dev_env/be/be/settings.py
+++ b/transendence_dev_env/be/be/settings.py
@@ -113,8 +113,8 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),  # Keep your original access token lifetime
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=2),  # Keep your original refresh token lifetime
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),  # Keep your original access token lifetime
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=7),  # Keep your original refresh token lifetime
     'ROTATE_REFRESH_TOKENS': True,  # Rotate refresh tokens upon use
     'BLACKLIST_AFTER_ROTATION': True,  # Blacklist old refresh tokens after they are used
     'ALGORITHM': 'HS256',

--- a/transendence_dev_env/be/be/settings.py
+++ b/transendence_dev_env/be/be/settings.py
@@ -113,7 +113,7 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=1000),  # Keep your original access token lifetime
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=8),  # Keep your original access token lifetime
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),  # Keep your original refresh token lifetime
     'ROTATE_REFRESH_TOKENS': True,  # Rotate refresh tokens upon use
     'BLACKLIST_AFTER_ROTATION': True,  # Blacklist old refresh tokens after they are used

--- a/transendence_dev_env/be/be/settings.py
+++ b/transendence_dev_env/be/be/settings.py
@@ -113,7 +113,7 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=8),  # Keep your original access token lifetime
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=120),  # Keep your original access token lifetime
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),  # Keep your original refresh token lifetime
     'ROTATE_REFRESH_TOKENS': True,  # Rotate refresh tokens upon use
     'BLACKLIST_AFTER_ROTATION': True,  # Blacklist old refresh tokens after they are used

--- a/transendence_dev_env/fe/src/app/auth.guard.ts
+++ b/transendence_dev_env/fe/src/app/auth.guard.ts
@@ -11,6 +11,8 @@ export class AuthGuard implements CanActivate {
   canActivate(): boolean {
     // Check if the user is authenticated (JWT token is valid)
     if (!this.authService.isAuthenticated()) {
+      // this.authService.refreshTokenIfNeeded();  we should somehow try to refresh the token in here
+
       // console.log('Not authenticated, redirecting to /login');
       // this.router.navigate(['/login']);
       return true;

--- a/transendence_dev_env/fe/src/app/auth.guard.ts
+++ b/transendence_dev_env/fe/src/app/auth.guard.ts
@@ -12,12 +12,12 @@ export class AuthGuard implements CanActivate {
     // Check if the user is authenticated (JWT token is valid)
     if (!this.authService.isAuthenticated()) {
       // console.log('Not authenticated, redirecting to /login');
-      this.router.navigate(['/login']);
-      return false;
+      // this.router.navigate(['/login']);
+      return true;
     }
 
     // console.log('Access granted by AuthGuard');
     return true;
   }
-  
+
 }

--- a/transendence_dev_env/fe/src/app/auth.guard.ts
+++ b/transendence_dev_env/fe/src/app/auth.guard.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { AuthService } from './auth.service';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+
 
 @Injectable({
   providedIn: 'root'
@@ -8,18 +11,24 @@ import { AuthService } from './auth.service';
 export class AuthGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(): boolean {
-    // Check if the user is authenticated (JWT token is valid)
+  canActivate(): Observable<boolean> | Promise<boolean> | boolean {
     if (!this.authService.isAuthenticated()) {
-      // this.authService.refreshTokenIfNeeded();  we should somehow try to refresh the token in here
-
-      // console.log('Not authenticated, redirecting to /login');
-      // this.router.navigate(['/login']);
-      return true;
+      return this.authService.refreshTokenIfNeeded().pipe(
+        map(token => {
+          if (token) {
+            return true; // Token was refreshed successfully
+          } else {
+            this.router.navigate(['/login']);
+            return false; // Token refresh failed
+          }
+        }),
+        catchError(() => {
+          this.router.navigate(['/login']);
+          return of(false);
+        })
+      );
     }
 
-    // console.log('Access granted by AuthGuard');
-    return true;
+    return true; // User is already authenticated
   }
-
 }

--- a/transendence_dev_env/fe/src/app/auth.interceptor.ts
+++ b/transendence_dev_env/fe/src/app/auth.interceptor.ts
@@ -51,7 +51,7 @@ export class AuthInterceptor implements HttpInterceptor {
 
   private addTokenToRequest(req: HttpRequest<any>, with_creds: boolean): HttpRequest<any> {
     let token = this.authService.getAccessToken();
-    console.debug('Adding token to request, token: ', token);
+    // console.debug('Adding token to request, token: ', token);
     return req.clone({
       setHeaders: {
         Authorization: `Bearer ${token}`
@@ -71,20 +71,20 @@ export class AuthInterceptor implements HttpInterceptor {
           this.isRefreshing = false;
 
           if (newToken) {
-            console.log('Token refreshed successfully');
+            // console.log('Token refreshed successfully');
             // this.authService.setAccessToken(newToken);
             this.refreshTokenSubject.next(newToken);
             // Retry the failed request with the new token
             return next.handle(this.addTokenToRequest(req, false));
           } else {
-            console.log('Failed to refresh token');
+            console.error('Failed to refresh token');
             // If we didn't get a new token, logout the user
             this.authService.logout('Failed to refresh token');
             return throwError(() => new Error('Failed to refresh token'));
           }
         }),
         catchError((err) => {
-          console.log('Error refreshing token:', err);
+          console.error('Error refreshing token:', err);
           // If there's an error during refresh, logout the user
           this.isRefreshing = false;
           this.authService.logout('Failed to refresh token');
@@ -93,7 +93,7 @@ export class AuthInterceptor implements HttpInterceptor {
       );
     } else {
       // If refresh is in progress, queue the requests
-      console.log('Refresh token in progress, queuing request');
+      // console.log('Refresh token in progress, queuing request');
       return this.refreshTokenSubject.pipe(
         filter(token => token != null),
         take(1),

--- a/transendence_dev_env/fe/src/app/auth.service.ts
+++ b/transendence_dev_env/fe/src/app/auth.service.ts
@@ -164,7 +164,7 @@ export class AuthService {
   refreshTokenIfNeeded(): Observable<string | null> {
     // console.debug('Refreshing JWT token...');
     // Prevent multiple refresh calls if a refresh is already in progress
-    if (this.refreshInProgress) {
+    if (this.refreshInProgress) {  // could get triggered if we have two call one by Interceptor and one by AuthGuard
       console.error('Refresh token process already in progress');
       return throwError('Refresh token process already in progress');
     }

--- a/transendence_dev_env/fe/src/app/auth.service.ts
+++ b/transendence_dev_env/fe/src/app/auth.service.ts
@@ -162,7 +162,7 @@ export class AuthService {
   }
 
   refreshTokenIfNeeded(): Observable<string | null> {
-    console.debug('Refreshing JWT token...');
+    // console.debug('Refreshing JWT token...');
     // Prevent multiple refresh calls if a refresh is already in progress
     if (this.refreshInProgress) {
       console.error('Refresh token process already in progress');
@@ -174,7 +174,7 @@ export class AuthService {
     return this.http.post(`${this.apiUrl}/accounts/token/refresh/`, {}, { withCredentials: true }).pipe(
       tap((response: any) => {
         if (response && response.access) {
-          console.debug('Token refreshed successfully, new token: ', response.access);
+          // console.debug('Token refreshed successfully, new token: ', response.access);
           this.storeTokens(response.access);
           this.websocketService.connectNotifications(response.access);
           this.refreshInProgress = false; // idk maybe its useful


### PR DESCRIPTION
So JWT auth token refreshing was a mess and couldn't work.

Now refreshing works fine, however the interceptor only intercepts requests from within the client (?), but we trigger some requests in the UI to static links (for example the header "Games", "Leaderboard") etc, which don't go through the Interceptor and therefore will still fail and log us out if the token expired, i don't know how to handle this correctly rn.
Also not sure yet if refresh token cycling works correctly. But this is already fixing part of the problem.

Also this code is horrible because i never wrote TS before, feel free to refactor it smh?